### PR TITLE
Remove suppression behavior of scheduler

### DIFF
--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -286,9 +286,8 @@ function scheduler()
         catch ex
             if isa(ex, InterruptException)
                 set_scheduler_while_loop(false)
-            else
-                throw(ex)
             end
+            throw(ex)
         end
     end
     @debug "scheduler() end"

--- a/src/scheduler.jl
+++ b/src/scheduler.jl
@@ -281,10 +281,14 @@ function scheduler()
     while SCHEDULER_WHILE_LOOP
         @debug "scheduler() new loop"
         update_queue!()
-        try # if someone sends ctrl + C to sleep, scheduler wont stop.
+        try
             sleep(SCHEDULER_UPDATE_SECOND)
         catch ex
-            @warn "JobScheduler.scheduler(): interruption signal received but suppressed."
+            if isa(ex, InterruptException)
+                set_scheduler_while_loop(false)
+            else
+                throw(ex)
+            end
         end
     end
     @debug "scheduler() end"


### PR DESCRIPTION
This PR matches on an `InterruptException` and stops the scheduler. Exceptions are no longer suppressed by the scheduler loop and are thrown.

The people on my team have found the current behavior unexpected; the user expects to be able to stop the service with `Ctrl+C`. Additionally, `scheduler_stop` doesn't handle scenarios when you may want to stop the scheduler. I couldn't find any resources in the Julia language on why the 'try...catch' should be avoided, but I think [this Python article](https://realpython.com/the-most-diabolical-python-antipattern/) illustrates why universal exception catching is confusing behavior.

I really appreciate your work with JobSchedulers.jl and I hope this PR can help improve this library. Let me know if you'd like me to make any changes to this PR.